### PR TITLE
fix: find project file using substring

### DIFF
--- a/lua/telescope/_extensions/scaladex/helpers.lua
+++ b/lua/telescope/_extensions/scaladex/helpers.lua
@@ -4,7 +4,7 @@ local M = {}
 
 local function contains(list, text)
   for _, v in pairs(list) do
-    if v == text then
+    if string.find(v, text) then
       return true
     end
   end


### PR DESCRIPTION
Hi! I was just trying to build a dependency picker for scala and after failing I found your Telescope extension! 

Just noticed that it didn't properly detect when on a sbt or mill project.

The root cause is that `require('plenary.scandir').scan_dir('.')` returns a list of files relative to `.`, so `build.sbt` is actually `./build.sbt`. Since it was being checked with an exact match against `build.sbt`, it always returned false. Using `string.find` should fix the issue